### PR TITLE
Merge from master: fix brightness/slider selection, release 1.11.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 Version 1.11.0
 ~~~~~~~~~~~~~~
 
+* backlight-helper: Add gmux_backlight to backlight_interfaces
+* Switch to org.gnome.SessionManager
+* Show vendor/model information
+* Fixes change keyboard back light for laptops with levels less then 10
+
 Version 1.10.1
 ~~~~~~~~~~~~~~
 Released: 2015-07-14


### PR DESCRIPTION
Merge from master: fix brightness/slider selection, release 1.11.0  This required reverting changes to brightness-applet.c that were incompatable. 